### PR TITLE
Creality Bundle Enhancements for Ender-3 Pro

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -32,6 +32,15 @@ bed_model = ender3_bed.stl
 bed_texture = ender3.svg
 default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY
 
+[printer_model:ENDER3PRO]
+name = Creality Ender-3 Pro
+variants = 0.4
+technology = FFF
+family = ENDER
+bed_model = ender3_bed.stl
+bed_texture = ender3.svg
+default_materials = Generic PLA @CREALITY; Generic PETG @CREALITY; Generic ABS @CREALITY; Creality PLA @CREALITY; Prusament PLA @CREALITY; Prusament PETG @CREALITY; AzureFilm PLA @CREALITY; Devil Design PLA @CREALITY; Devil Design PLA Matt @CREALITY; Devil Design PLA Galaxy @CREALITY; Extrudr PLA NX2 @CREALITY; Real Filament PLA @CREALITY; Velleman PLA @CREALITY; 3DJAKE ecoPLA @CREALITY; 3DJAKE ecoPLA Matt @CREALITY; 3DJAKE ecoPLA Tough @CREALITY; 123-3D Jupiter PLA @CREALITY
+
 [printer_model:ENDER3V2]
 name = Creality Ender-3 V2
 variants = 0.4
@@ -959,6 +968,14 @@ printer_notes = Don't remove the following keywords! These keywords are used in 
 inherits = Creality Ender-3; *fastabl*
 renamed_from = "Creality ENDER-3 BLTouch"
 printer_model = ENDER3BLTOUCH
+
+[printer:Creality Ender-3 Pro]
+inherits = *common*
+renamed_from = "Creality Ender-3 Pro"
+bed_shape = 5x0,215x0,215x220,5x220
+max_print_height = 250
+printer_model = ENDER3PRO
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_CREALITY\nPRINTER_MODEL_ENDER3PRO\nPRINTER_HAS_BOWDEN
 
 [printer:Creality Ender-3 V2]
 inherits = *common*


### PR DESCRIPTION
For the consideration of the PrusaSlicer team.  With regards to the Creality Ender-3 Pro, that's based on the current information of the printer being sold in stores around the world.  The printer is an enhanced version of the existing Creality Ender-3, that contains a wider Y-axis, upgraded power supply, and magnetic print bed.

I was surprised to not see this printer in the configuration given the popularity of the model, if there is a reason it hasn't been included to date, would you mind reconsidering that request to make this great software more approachable to those who use this model of printer.

Thank you for your consideration.